### PR TITLE
Allow use of RDS admin account instead of sys.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,3 +71,25 @@ jobs:
         with:
           name: build_logs-ready-database
           path: ./**/*.log
+  rds-variations:
+    name: Test RDS deployment tweaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4.2.2
+      - name: Clean Runner
+        uses: ./.github/actions/clean-runner
+      - name: setup java
+        uses: actions/setup-java@v4.6.0
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Install Schema using RDS variations (no direct sys)
+        working-directory: schema
+        run: ant docker.install.rds
+      - name: Upload Build Logs
+        if: success() || failure() # always run even if the previous step fails
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: build_logs-ready-database
+          path: ./**/*.log

--- a/schema/build.xml
+++ b/schema/build.xml
@@ -102,13 +102,21 @@
 
    <!-- Create CWMS schema build user -->
    <target name="createbuilduser" description="creates user to build CWMS schema" depends="init">
-                <echo message="Create build user"/>
-                <exec dir="${root}" executable="sqlplus">
-                        <arg value="sys/${oracle.sys.password}@${oracle.cwms.instance} as sysdba" />
-                        <arg value="@builduser_grants"/>
-                        <arg value="${oracle.builduser}"/>
-                        <arg value="${oracle.builduser.password}"/>
-                </exec>
+      <if>
+         <not><equals arg1="${oracle.sys.password}" arg2=""/></not>
+         <then>
+            <echo message="Create build user"/>
+            <exec dir="${root}" executable="sqlplus">
+               <arg value="sys/${oracle.sys.password}@${oracle.cwms.instance} as sysdba" />
+               <arg value="@builduser_grants"/>
+               <arg value="${oracle.builduser}"/>
+               <arg value="${oracle.builduser.password}"/>
+            </exec>
+         </then>
+         <else>
+            <echo message="Assuming provided build user is already created."/>
+         </else>
+      </if>
    </target>
 
    <target name="build" description="Executes python3 scripts to build the CWMS schema" depends="createbuilduser,database-version">
@@ -1250,6 +1258,8 @@
       <attribute name="database-name"/>
       <attribute name="sys-password"/>
       <attribute name="cwms-password"/>
+      <attribute name="builduser" default=""/>
+      <attribute name="rds-mode" default="false"/>
       <attribute name="builduser-password"/>
       <attribute name="office-id"/>
       <attribute name="office-eroc"/>
@@ -1267,9 +1277,13 @@
             <arg value="-e"/>
             <arg value="DB_NAME=/@{database-name}"/>
             <arg value="-e"/>
-            <arg value="SYS_PASSWORD=@{sys-password}"/>
+            <arg value="SYS_PASSWORD=@{sys-password}"/>      
             <arg value="-e"/>
             <arg value="CWMS_PASSWORD=@{cwms-password}"/>
+            <arg value="-e"/>
+            <arg value="RDS_MODE=@{rds-mode}"/>
+            <arg value="-e"/>
+            <arg value="BUILDUSER=@{builduser}"/>
             <arg value="-e"/>
             <arg value="BUILDUSER_PASSWORD=@{builduser-password}"/>
             <arg value="-e"/>
@@ -1292,6 +1306,35 @@
          host-and-port="${database.host_and_port}"
          database-name="${database.name}"
          sys-password="${database.syspw}"
+         cwms-password="${database.cwmspw}"
+         builduser-password="${database.buildpw}"
+         office-id="${database.office}"
+         office-eroc="${database.eroc}"
+      />
+   </target>
+
+   <target name="docker.install.rds" depends="docker.prepdb, docker.buildimage"
+      description="Mimics RDS admin user for testing, creates build user. Task is not suitable for actual RDS install.">
+      <echo message="Using Docker build to install database, mimicing RDS Oracle Admin account setup."/>
+      <getdockerport property="rds.external_port" container="${docker.props.container_name_valid}"/>
+      <property name="oracle.builduser" value="builduser"/>
+      <exec dir="${root}" executable="sqlplus">
+         <arg value="sys/${database.syspw}@localhost:${rds.external_port}/${database.name} as sysdba" />
+         <arg value="@builduser_grants"/>
+         <arg value="${oracle.builduser}"/>
+         <arg value="${database.buildpw}"/>
+      </exec>
+      <exec dir="${root}" executable="sqlplus">
+         <arg value="sys/${database.syspw}@localhost:${rds.external_port}/${database.name} as sysdba" />
+         <arg value="@data_file_dest"/>
+      </exec>
+      <docker.install_schema image="${docker.props.image_name}" output-file="build/buildCWMS_DB-rds.log"
+         network="${docker.props.network_name}"
+         host-and-port="${database.host_and_port}"
+         database-name="${database.name}"
+         sys-password=""
+         rds-mode="true"
+         builduser="${oracle.builduser}"
          cwms-password="${database.cwmspw}"
          builduser-password="${database.buildpw}"
          office-id="${database.office}"

--- a/schema/data_file_dest.sql
+++ b/schema/data_file_dest.sql
@@ -1,0 +1,1 @@
+alter system set db_create_file_dest = '/opt/oracle/oradata';

--- a/schema/docker/install.sh
+++ b/schema/docker/install.sh
@@ -5,6 +5,7 @@ echo "DB HOST_PORT: $DB_HOST_PORT"
 echo "DB NAME: $DB_NAME"
 echo "OFFICE_ID: $OFFICE_ID"
 echo "OFFICE_EROC: $OFFICE_EROC"
+echo "RDS_MODE: $RDS_MODE"
 if [ "$CWMS_PASSWORD" ==  "" ]
 then
     export CWMS_PASSWORD=`tr -cd '[:alnum:]' < /dev/urandom | fold -w25 | head -n1`
@@ -28,17 +29,27 @@ then
     export SUB_DB_NAME="\\$DB_NAME"
 fi
 
-if [ "$SYS_PASSWORD" == "" ]
+if [[ "$SYS_PASSWORD" == "" && "$RDS_MODE" != "true" ]]
 then
     echo "SYS password for database must be supplied (-e SYS_PASSWORD=<pw> )"
     exit 1
+elif [[ "$RDS_MODE" == "true" ]]
+then
+    SYS_PASSWORD=""
 fi
 
-if [ "$BUILDUSER_PASSWORD" == "" ]
+if [ "$BUILDUSER" == "" && "$RDS_MODE" != "true" ]
+then
+    BUILDUSER=builduser
+fi
+
+if [[ "$BUILDUSER_PASSWORD" == "" && "$RDS_MODE" != "true" ]]
 then
     export BUILDUSER_PASSWORD=`tr -cd '[:alnum:]' < /dev/urandom | fold -w25 | head -n1`
-    #echo "Build user password must be supplied ( -e BUILDUSER_PASSWORD=<pw> )"
-    #exit 1
+elif [[ "$BUILDUSER_PASSWORD" == "" && "$RDS_MODE" == "true" ]]
+then
+    echo "Build user password must be supplied "
+    exit 1
 fi
 
 cd /cwmsdb/schema
@@ -47,6 +58,7 @@ echo $DB_NAME
 sed -e "s/HOST_AND_PORT/$DB_HOST_PORT/g" \
     -e "s/\/SERVICE_NAME/$SUB_DB_NAME/g" \
     -e "s/BUILDUSER_PASS/$BUILDUSER_PASSWORD/g" \
+    -e "s/BUILDUSER/$BUILDUSER/g" \
     -e "s/OFFICE_ID/$OFFICE_ID/g" \
     -e "s/OFFICE_CODE/$OFFICE_EROC/g" \
     -e "s/TEST_ACCOUNT_FLAG/$TEST_ACCOUNT/g" \
@@ -55,25 +67,33 @@ sed -e "s/HOST_AND_PORT/$DB_HOST_PORT/g" \
  # TODO: create lookup system for office code
 
 cat /overrides.xml
-TABLESPACE_DIR="/opt/oracle/oradata"
-#echo "Installing APEX"
-#cd /opt/apex/apex
-#sqlplus sys/$SYS_PASSWORD@$DB_HOST_PORT$DB_NAME as sysdba <<END
-#    alter system set db_create_file_dest = '/opt/oracle/oradata';
-#    create tablespace apex datafile '/opt/oracle/oradata/apex01.dat' size 100M autoextend on next 1M;
-#END
 
-#sqlplus sys/$SYS_PASSWORD@$DB_HOST_PORT$DB_NAME as sysdba @apexins.sql APEX APEX TEMP /i/
 
-echo "Creating table spaces at sys/$SYS_PASSWORD@$DB_HOST_PORT$DB_NAME as sysdba"
-sqlplus sys/$SYS_PASSWORD@$DB_HOST_PORT$DB_NAME as sysdba <<END
-    CREATE TABLESPACE "CWMS_20AT_DATA" DATAFILE 'at_data.dat' size 20M autoextend on next 10M;
-    CREATE TABLESPACE "CWMS_20DATA" DATAFILE 'data.dat' size 20M autoextend on next 10M;
-    CREATE TABLESPACE "CWMS_20_TSV" DATAFILE 'tsv.dat' size 20M autoextend on next 10M;
-    CREATE TABLESPACE "CWMS_AQ" DATAFILE 'aq.dat' size 20M autoextend on next 10M;
-    CREATE TABLESPACE "CWMS_AQ_EX" DATAFILE 'aq_ex.dat' size 20M autoextend on next 10M;
 
-END
+
+if [ "$RDS_MODE" == "true" ]
+then
+    CONNECTION_STR="$BUILDUSER/$BUILDUSER_PASSWORD@$DB_HOST_PORT$DB_NAME"
+    cat > /tmp/tablespaces.sql <<EOF
+CREATE TABLESPACE "CWMS_20AT_DATA" DATAFILE  size   2G autoextend on next 100M maxsize UNLIMITED;
+CREATE TABLESPACE "CWMS_20DATA"    DATAFILE  size   2G autoextend on next 100M maxsize UNLIMITED;
+CREATE TABLESPACE "CWMS_20_TSV"    DATAFILE  size   5G autoextend on next 500M maxsize UNLIMITED;
+CREATE TABLESPACE "CWMS_AQ"        DATAFILE  size   1G autoextend on next 100M maxsize UNLIMITED;
+CREATE TABLESPACE "CWMS_AQ_EX"     VDATAFILE size 200M autoextend on next 100M maxsize UNLIMITED;
+EOF
+else
+    CONNECTION_STR="sys/$SYS_PASSWORD@$DB_HOST_PORT$DB_NAME as sysdba"
+    cat > /tmp/tablespaces.sql <<EOF
+CREATE TABLESPACE "CWMS_20AT_DATA" DATAFILE 'at_data.dat' size 20M autoextend on next 10M maxsize UNLIMITED;
+CREATE TABLESPACE "CWMS_20DATA"    DATAFILE 'data.dat'    size 20M autoextend on next 10M maxsize UNLIMITED;
+CREATE TABLESPACE "CWMS_20_TSV"    DATAFILE 'tsv.dat'     size 20M autoextend on next 10M maxsize UNLIMITED;
+CREATE TABLESPACE "CWMS_AQ"        DATAFILE 'aq.dat'      size 20M autoextend on next 10M maxsize UNLIMITED;
+CREATE TABLESPACE "CWMS_AQ_EX"     DATAFILE 'aq_ex.dat'   size 20M autoextend on next 10M maxsize UNLIMITED;
+EOF
+fi
+
+echo "Creating table spaces at $CONNECTION_STR"
+sqlplus $CONNECTION_STR @/tmp/tablespaces.sql
 
 function run_user_data()
 {

--- a/schema/docker/overrides.template.xml
+++ b/schema/docker/overrides.template.xml
@@ -20,11 +20,11 @@
 
 	<!-- oracle user to build CWMS schema -->
 
-	<property name="oracle.builduser" value="builduser"/>
+	<property name="oracle.builduser" value="@BUILDUSER@"/>
 
 	<!-- oracle.builduser password -->
 
-	<property name="oracle.builduser.password" value="${database.buildpw}"/>
+	<property name="oracle.builduser.password" value="@BUILDUSER_PASS@"/>
 
  	<!-- the oracle user to install to the oracle instance. -->
 

--- a/schema/teamcity_overrides.xml
+++ b/schema/teamcity_overrides.xml
@@ -20,7 +20,7 @@
 
 	<!-- oracle user to build CWMS schema -->
 
-	<property name="oracle.builduser" value="builduser"/>
+	<property name="oracle.builduser" value="BUILDUSER"/>
 
 	<!-- oracle.builduser password -->
 
@@ -97,5 +97,3 @@
 	<!-- end of properties for oracle cc build. -->
 
 </project>
-
-


### PR DESCRIPTION
* Alter createbuilduser to avoid creation if already exists
* Added RDS_MODE to installer to require build user information and remove sys information
* Added docker.install.rds target to aid in testing functionality.

`docker.install.rds` target added to job for build checks.