### PR TITLE
Add 'builduser' as an allowed admin bypass option.

### DIFF
--- a/schema/src/autobuild.py
+++ b/schema/src/autobuild.py
@@ -36,6 +36,7 @@ define echo_state = %s
 define inst = %s
 define cwms_schema = %s
 define host_office = %s
+define builduser = %s
 '''
 
 restricted = False
@@ -57,7 +58,7 @@ cwms_schema = cwms_schema.upper()
 inst = inst.upper()
 
 auto_block = auto_block_template % (echo, inst, builduser, builduser_passwd, cwms_schema, cwms_passwd, pd_passwd, test_passwd)
-defines_block = defines_block_template % (echo, inst, cwms_schema, pd_office)
+defines_block = defines_block_template % (echo, inst, cwms_schema, pd_office, builduser)
 
 f = open(manual_sqlfilename, "r")
 sql_script = f.read()

--- a/schema/src/cwms/create_sec_triggers.sql
+++ b/schema/src/cwms/create_sec_triggers.sql
@@ -29,7 +29,7 @@ BEGIN
              l_priv   VARCHAR2 (16);
              BEGIN
              l_priv := NVL(SYS_CONTEXT (''CWMS_ENV'', ''CWMS_PRIVILEGE''),''''); 
-             IF (l_priv <> ''CAN_WRITE'' AND user NOT IN (''SYS'', ''&cwms_schema'')'
+             IF (l_priv <> ''CAN_WRITE'' AND user NOT IN (''SYS'', ''&cwms_schema'', ''&builduser'')'
           || l_upass 
           || ')
              THEN
@@ -60,7 +60,7 @@ BEGIN
              l_priv   VARCHAR2 (16);
              BEGIN
              l_priv := NVL(SYS_CONTEXT (''CWMS_ENV'', ''CWMS_PRIVILEGE''),''''); 
-             IF ((l_priv <> ''CAN_WRITE'') AND (l_priv <> ''CAN_LOGIN'') AND user NOT IN (''SYS'', ''&cwms_schema''))
+             IF ((l_priv <> ''CAN_WRITE'') AND (l_priv <> ''CAN_LOGIN'') AND user NOT IN (''SYS'', ''&cwms_schema'', ''&builduser''))
              THEN
      
                CWMS_20.CWMS_ERR.RAISE(''NO_WRITE_PRIVILEGE'');

--- a/schema/src/cwms/cwms_sec_pkg_body.sql
+++ b/schema/src/cwms/cwms_sec_pkg_body.sql
@@ -12,7 +12,7 @@ AS
         --
         -- CWMS_20, system, sys are ok
         --
-        IF l_username IN ('CWMS_20', 'SYSTEM', 'SYS')
+        IF l_username IN ('&&cwms_schema', 'SYSTEM', 'SYS', '&&builduser')
         THEN
             RETURN FALSE;
         END IF;
@@ -52,7 +52,7 @@ AS
         --
         -- CWMS_20, system, sys are ok
         --
-        IF l_username IN ('CWMS_20', 'SYSTEM', 'SYS')
+        IF l_username IN ('&&cwms_schema', 'SYSTEM', 'SYS', '&&builduser')
         THEN
             RETURN TRUE;
         END IF;

--- a/schema/src/cwms/cwms_util_pkg_body.sql
+++ b/schema/src/cwms/cwms_util_pkg_body.sql
@@ -551,7 +551,9 @@ as
 
          IF l_office_id IS NULL
          THEN
-            IF l_username = '&cwms_schema' or l_username = 'NOBODY' or l_username = 'CCP' or l_username = 'SYS' or upper(l_username) = upper(l_upass_id)
+            IF l_username = '&cwms_schema' or l_username = 'NOBODY' or 
+               l_username = 'CCP' or l_username = 'SYS' or upper(l_username) = upper(l_upass_id) or
+               l_username = '&builduser'
             THEN
                l_office_id := 'CWMS';
             ELSE

--- a/schema/src/cwms/tables/at_ts_extents.sql
+++ b/schema/src/cwms/tables/at_ts_extents.sql
@@ -72,7 +72,7 @@ create or replace TRIGGER ST_TS_EXTENTS BEFORE DELETE OR INSERT OR UPDATE
              l_priv   VARCHAR2 (16);
              BEGIN
              SELECT SYS_CONTEXT ('CWMS_ENV', 'CWMS_PRIVILEGE') INTO l_priv FROM DUAL;
-             IF ((l_priv is NULL OR l_priv <> 'CAN_WRITE') AND user NOT IN ('SYS', 'CWMS_20'))
+             IF ((l_priv is NULL OR l_priv <> 'CAN_WRITE') AND user NOT IN ('SYS', '&&cwms_schema', '&&builduser'))
              THEN
 
                CWMS_20.CWMS_ERR.RAISE('NO_WRITE_PRIVILEGE');


### PR DESCRIPTION
NOTE: The general need for this is specific to AWS automated operations, hence why it's only happening here at the moment.