### PR TITLE
Additional permissions needed for OpenDCS manageDatabase

### DIFF
--- a/schema/builduser_grants.sql
+++ b/schema/builduser_grants.sql
@@ -8,6 +8,11 @@ grant select on dba_scheduler_jobs to &builduser with grant option;
 grant select on dba_scheduler_job_log to &builduser with grant option;
 grant select on dba_scheduler_job_run_details to &builduser with grant option;
 
+grant select on dba_queues to &builduser with grant option;
+grant select on dba_queue_subscribers to &builduser with grant option;
+grant select on dba_subscr_registrations to &builduser with grant option;
+grant execute on dbms_session to &builduser with grant option;
+
 grant execute on dbms_crypto to &builduser with grant option;
 grant execute on dbms_aq to &builduser with grant option;
 grant execute on dbms_aq_bqview to &builduser with grant option;


### PR DESCRIPTION
When creating a fresh database with OpenDCS,  builduser doesn't have enough permissions.

Below is the error (using image pulled today).  My workaround has been to manually add permissions to builduser.

```bash
server:~$ docker run  --rm -d -p 1521:1521 --name opendcs-oracle         -e ORACLE_PASSWORD="test"          -e CWMS_PASSWORD="test"         -e OFFICE_ID="HQ"         -e OFFICE_EROC="s0"         ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:latest-dev

```

```txt

opendcs\bin>manageDatabase  -d 3 -P "%appdata%\.opendcs\nwdm-test.profile" -username builduser -password test -appUsername karl -appPassword test -I CWMS-Oracle -DCWMS_SCHEMA=CWMS_20 -DCCP_SCHEMA=CCP -DDEFAULT_OFFICE_CODE=30  -DDEFAULT_OFFICE=NWDM
Migrating Database:
Please provide values for each of the presented properties.
TABLE_SPACE_SPEC (desc = If data will be on a separate table space indicate the line here.) =
Installing fresh database
Exception in thread "main" org.flywaydb.core.api.FlywayException: Error while executing beforeMigrate callback: Migration beforeMigrate__set_schema_permissions.sql failed
----------------------------------------------------------
SQL State  : 42000
Error Code : 1031
Message    : ORA-01031: insufficient privileges
ORA-06512: at line 27
ORA-01403: no data found
ORA-06512: at line 7

https://docs.oracle.com/error-help/db/ora-01031/
Location   : db/CWMS-Oracle/callbacks/beforeMigrate__set_schema_permissions.sql (C:\project\opendcs\install\build\install\opendcs\bin\file:\C:\project\opendcs\install\build\install\opendcs\bin\opendcs.jar!\db\CWMS-Oracle\callbacks\beforeMigrate__set_schema_permissions.sql)
Line       : 26
Statement  : -- The way to assign these specific privileges different when running in an Oracle RDS database.
-- NOTE: These go away when if/when CWMS is no longer using the Oracle queues for it's queue system.
declare
    is_rds char := 'N';
begin
    begin
        select 'Y' into is_rds from dba_users where username='RDSADMIN';
        execute immediate 'begin rdsadmin.rdsadmin_util.grant_sys_object('||
            'p_obj_name     => ''DBA_SUBSCR_REGISTRATIONS'','||
            'p_grantee      => ''CCP'','||
            'p_privilege    => ''SELECT'','||
            'p_grant_option => true); end;';
        execute immediate 'begin dbms_aqadm.grant_system_privilege ('||
            'privilege    => ''enqueue_any'','||
            'grantee      => ''CCP'','||
            'admin_option => false); end;';
        execute immediate 'begin dbms_aqadm.grant_system_privilege ('||
            'privilege    => ''dequeue_any'','||
            'grantee      => ''CCP'','||
            'admin_option => false); end;';
        execute immediate 'begin dbms_aqadm.grant_system_privilege ('||
            'privilege    => ''manage_any'','||
            'grantee      => ''CCP'','||
            'admin_option => false); end;';
    exception
    when no_data_found then
        execute immediate 'GRANT SELECT ON dba_subscr_registrations to CCP';
        sys.dbms_aqadm.grant_system_privilege (
          privilege    => 'enqueue_any',
          grantee      => 'CCP',
          admin_option => false);
        sys.dbms_aqadm.grant_system_privilege (
          privilege    => 'dequeue_any',
          grantee      => 'CCP',
          admin_option => false);
        sys.dbms_aqadm.grant_system_privilege (
          privilege    => 'manage_any',
          grantee      => 'CCP',
          admin_option => false);
    end;
    execute immediate 'GRANT SELECT ON dba_scheduler_jobs to CCP';
    execute immediate 'GRANT SELECT ON dba_queue_subscribers to CCP';
    execute immediate 'GRANT SELECT ON dba_queues to CCP';
    execute immediate 'GRANT EXECUTE ON dbms_aq TO CCP';
    execute immediate 'GRANT EXECUTE ON dbms_aqadm TO CCP';
    execute immediate 'GRANT EXECUTE ON DBMS_SESSION to CCP';
    execute immediate 'GRANT EXECUTE ON DBMS_RLS to CCP';
end;

        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.handleEvent(DefaultCallbackExecutor.java:136)
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.execute(DefaultCallbackExecutor.java:129)
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.lambda$execute$0(DefaultCallbackExecutor.java:116)
        at org.flywaydb.core.internal.jdbc.TransactionalExecutionTemplate.execute(TransactionalExecutionTemplate.java:55)
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.execute(DefaultCallbackExecutor.java:114)
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.onMigrateOrUndoEvent(DefaultCallbackExecutor.java:70)
        at org.flywaydb.core.internal.command.DbMigrate.migrate(DbMigrate.java:84)
        at org.flywaydb.core.Flyway.lambda$migrate$0(Flyway.java:176)
        at org.flywaydb.core.FlywayExecutor.execute(FlywayExecutor.java:204)
        at org.flywaydb.core.Flyway.migrate(Flyway.java:128)
        at org.opendcs.database.MigrationManager.migrate(MigrationManager.java:82)
        at org.opendcs.database.ManageDatabaseApp.main(ManageDatabaseApp.java:84)
Caused by: org.flywaydb.core.internal.sqlscript.FlywaySqlScriptException: Migration beforeMigrate__set_schema_permissions.sql failed
```
