### PR TITLE
Fix problem with CWMS_TS.SET_REQUIRE_NEW_LRTS_FORMAT_ON_INPUT('F')

### DIFF
--- a/schema/src/cwms/cwms_ts_pkg.sql
+++ b/schema/src/cwms/cwms_ts_pkg.sql
@@ -33,14 +33,16 @@ AS
     * Input flag to store time series as LRTS is required only for old LRTS IDs in routintes that create time series.
     * May be ORed with g_use_new_lrts_ids_on_output.
     */
-   g_allow_new_lrts_ids_on_input   constant integer := 1;
+   g_allow_new_lrts_ids_on_input     constant integer := 1;
+   g_not_allow_new_lrts_ids_on_input constant integer := 4; -- bit mask to turn off
    /**
     * Constant specifing to require use of the new LRTS ID format on input in routines.
     * Old LRTS IDs will be interpreted strictly as PRTS.
     * Input flag to store time series as LRTS is ignored in routintes that create time series.
     * May be ORed with g_use_new_lrts_ids_on_output.
     */
-   g_require_new_lrts_ids_on_input constant integer := 2;
+   g_require_new_lrts_ids_on_input     constant integer := 2;
+   g_not_require_new_lrts_ids_on_input constant integer := 5; -- bit mask to turn off
    /**
     * Constant specifing to use the new LRTS ID format on output in routines and views.
     * LRTS IDs output from routines and views will be in new LRTS format.

--- a/schema/src/cwms/cwms_ts_pkg_body.sql
+++ b/schema/src/cwms/cwms_ts_pkg_body.sql
@@ -2905,6 +2905,17 @@ AS
       return format_lrts_output(p_ts_id, use_new_lrts_format_on_output = 'T' and is_lrts(p_ts_id, p_office_id) = 'T');
    end format_lrts_output;
    --------------------------------------------------------------------------------
+   -- function bitor
+   --------------------------------------------------------------------------------
+   function bitor(
+      p_value in binary_integer,
+      p_mask  in binary_integer)
+      return binary_integer
+   is
+   begin
+      return p_value + p_mask - bitand(p_value, p_mask);
+   end bitor;
+   --------------------------------------------------------------------------------
    -- procedure set_use_new_lrts_format_on_output
    --------------------------------------------------------------------------------
    procedure set_use_new_lrts_format_on_output(
@@ -2914,17 +2925,9 @@ AS
    begin
       case upper(substr(p_use_new_format, 1, 1))
       when 'T' then
-         if bitand(l_current, g_use_new_lrts_ids_on_output) != g_use_new_lrts_ids_on_output then
-            cwms_util.set_session_info(
-               'USE_NEW_LRTS_ID_FORMAT',
-               l_current + g_use_new_lrts_ids_on_output - bitand(l_current, g_use_new_lrts_ids_on_output)); -- bitor
-         end if;
+         cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', bitor(l_current, g_use_new_lrts_ids_on_output));
       when 'F' then
-         if bitand(l_current, g_use_new_lrts_ids_on_output) = g_use_new_lrts_ids_on_output then
-            cwms_util.set_session_info(
-               'USE_NEW_LRTS_ID_FORMAT',
-               bitand(l_current, g_not_use_new_lrts_ids_on_output));
-         end if;
+         cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', bitand(l_current, g_not_use_new_lrts_ids_on_output));
       else
          cwms_err.raise('INVALID_T_F_FLAG', p_use_new_format);
       end case;
@@ -2952,21 +2955,9 @@ AS
    begin
       case upper(substr(p_allow_new_format, 1, 1))
       when 'T' then
-         if bitand(l_current, g_allow_new_lrts_ids_on_input) != g_allow_new_lrts_ids_on_input then
-            if bitand(l_current, g_use_new_lrts_ids_on_output) = g_use_new_lrts_ids_on_output then
-               cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', g_use_new_lrts_ids_on_output + g_allow_new_lrts_ids_on_input);
-            else
-               cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', g_allow_new_lrts_ids_on_input);
-            end if;
-         end if;
+         cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', bitor(bitand(l_current, g_not_require_new_lrts_ids_on_input), g_allow_new_lrts_ids_on_input));
       when 'F' then
-         if bitand(l_current, g_allow_new_lrts_ids_on_input) != g_allow_new_lrts_ids_on_input then
-            if bitand(l_current, g_use_new_lrts_ids_on_output) = g_use_new_lrts_ids_on_output then
-               cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', g_use_new_lrts_ids_on_output);
-            else
-               cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', 0);
-            end if;
-         end if;
+         cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', bitand(bitand(l_current, g_not_allow_new_lrts_ids_on_input), g_not_require_new_lrts_ids_on_input));
       else
          cwms_err.raise('INVALID_T_F_FLAG', p_allow_new_format);
       end case;
@@ -2994,21 +2985,9 @@ AS
    begin
       case upper(substr(p_require_new_format, 1, 1))
       when 'T' then
-         if bitand(l_current, g_require_new_lrts_ids_on_input) != g_require_new_lrts_ids_on_input then
-            if bitand(l_current, g_use_new_lrts_ids_on_output) = g_use_new_lrts_ids_on_output then
-               cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', g_use_new_lrts_ids_on_output + g_require_new_lrts_ids_on_input);
-            else
-               cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', g_require_new_lrts_ids_on_input);
-            end if;
-         end if;
+         cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', bitor(bitand(l_current, g_not_allow_new_lrts_ids_on_input), g_require_new_lrts_ids_on_input));
       when 'F' then
-         if bitand(l_current, g_require_new_lrts_ids_on_input) != g_require_new_lrts_ids_on_input then
-            if bitand(l_current, g_use_new_lrts_ids_on_output) = g_use_new_lrts_ids_on_output then
-               cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', g_use_new_lrts_ids_on_output);
-            else
-               cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', 0);
-            end if;
-         end if;
+         cwms_util.set_session_info('USE_NEW_LRTS_ID_FORMAT', bitand(bitand(l_current, g_not_require_new_lrts_ids_on_input), g_not_allow_new_lrts_ids_on_input));
       else
          cwms_err.raise('INVALID_T_F_FLAG', p_require_new_format);
       end case;

--- a/schema/src/test/test_timeseries_snapping.sql
+++ b/schema/src/test/test_timeseries_snapping.sql
@@ -64,7 +64,7 @@ begin
    cwms_loc.store_location(
       p_location_id  => c_location_id,
       p_time_zone_id => c_time_zone,
-      p_db_office_id => c_office_id);
+      p_db_office_id => c_office_id);   
 end setup;
 --------------------------------------------------------------------------------
 -- function make_timeseries
@@ -336,6 +336,8 @@ is
    l_ts_values_2 cwms_t_tsv_array;
    l_first_time  date;
 begin
+   cwms_ts.set_require_new_lrts_format_on_input('F');
+   cwms_ts.set_use_new_lrts_format_on_output('F');
    for i in 1..c_start_dates.count loop
       l_ts_values   := make_timeseries('LRTS', c_start_dates(i), c_interval_offset);
       l_ts_values_2 := trim_timeseries(l_ts_values, c_interval_offset, c_time_zone);


### PR DESCRIPTION
Calling `cwms_ts.set_require_new_lrts_format_on_input('F')` had no effect.
* Simplified code to set LRTS environment.
* Fixed test that used old LRTS names to set the LRTS environment before executing.