### PR TITLE
Add default parameters for override file.

### DIFF
--- a/schema/teamcity_overrides.xml
+++ b/schema/teamcity_overrides.xml
@@ -13,7 +13,7 @@
 	<!-- the oracle instance to install to. -->
 
  	<property name="oracle.cwms.instance" value="HOST_AND_PORT/SERVICE_NAME"/>
-
+	<property name="oracle.connection.parameters" value="?oracle.net.disableOob=true"/>
 
 
  	


### PR DESCRIPTION
Lack of this parameter is causing the cwbi-dev cda instance to no start due to the migration container failing to detect that the database is already installed.