### PR TITLE
Update Cache action

### DIFF
--- a/.github/actions/setup-oracle-clients/action.yml
+++ b/.github/actions/setup-oracle-clients/action.yml
@@ -4,7 +4,7 @@ runs:
   steps:
     - name: Oracle Tools
       id: cache-oracle-tools
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@v5.0.3
       with:
         path: oracle-tools
         key: oracle-tools-23.6


### PR DESCRIPTION
4.2.0 is now deprecated so may be causing the failed build that @rma-rripken is having.