### PR TITLE
update at_api_keys table to allow for a key_id column

### DIFF
--- a/schema/src/cwms/cwms_env_pkg.sql
+++ b/schema/src/cwms/cwms_env_pkg.sql
@@ -21,15 +21,6 @@ AS
     * @parameter p_office The office for a particular session.
    */
    PROCEDURE set_session_user_direct(p_user VARCHAR2, p_office VARCHAR2 default NULL);
-
-   /**
-    * For user by WEB_USER accounts, set the role given the provided apikey
-    *
-    * @parameter p_apikey A user authorization token with a user defined (default 1 day) lifetime.
-    * @parameter p_office The office required for a particular session.
-    *
-   */
-   PROCEDURE set_session_user_apikey(p_apikey VARCHAR2, p_office VARCHAR2 default NULL);
 END cwms_env;
 /
 

--- a/schema/src/cwms/cwms_env_pkg_body.sql
+++ b/schema/src/cwms/cwms_env_pkg_body.sql
@@ -166,14 +166,6 @@ AS
         raise;
    END set_session_user_direct;
 
-   PROCEDURE set_session_user_apikey(p_apikey VARCHAR2, p_office VARCHAR2)
-   IS
-      l_userid at_sec_cwms_users.userid%type := null;
-   BEGIN
-      select userid into l_userid from cwms_20.av_active_api_keys where apikey = p_apikey;
-      set_session_user_direct(l_userid,p_office);
-   end set_session_user_apikey;
-
    PROCEDURE set_session_privileges
    IS
       l_office_id   VARCHAR2 (16);

--- a/schema/src/cwms/tables/at_api_keys.sql
+++ b/schema/src/cwms/tables/at_api_keys.sql
@@ -1,25 +1,26 @@
 create table at_api_keys(
+    key_id raw(16) not null,
     userid varchar2(128) not null references at_sec_cwms_users(USERID),
     key_name varchar2(64) not null,
-    apikey varchar2(256) not null unique,    
-    created date default current_timestamp not null,
-    expires date default current_timestamp+1,
-    primary key(userid,key_name)
+    secret_hash varchar2(512) not null,
+    created timestamp default current_timestamp not null,
+    expires timestamp default current_timestamp+1,
+    constraint at_api_keys_pk primary key (key_id),
+    constraint at_api_keys_u1 unique (userid, key_name)
 );
-
-comment on column at_api_keys.apikey  is 
-        'While randomly generated, these still have to be unique. Applications generating them should check and provide a different value';
 
 create or replace trigger cwms_20.st_api_key_readonly
     before update on cwms_20.at_api_keys
     for each row
 begin
-    if(    :new.userid <> :old.userid
+    if(    (:new.userid <> :old.userid
         OR :new.key_name <> :old.key_name
-        OR :new.apikey <> :old.apikey
+        OR :new.secret_hash <> :old.secret_hash
         OR :new.created <> :old.created
+        OR :new.key_id <> :old.key_id)
+        AND :new.expires < :old.expires
     ) then
-        raise_application_error(-20001,'API Key table is unmodifiabled except to update expiration or by deletion.');
+        raise_application_error(-20001,'Only EXPIRES may be updated; all other columns are immutable.');
     end if;
 end;
 /

--- a/schema/src/cwms/views/av_active_api_keys.sql
+++ b/schema/src/cwms/views/av_active_api_keys.sql
@@ -1,8 +1,9 @@
 create or replace view av_active_api_keys as 
 select
+   key_id,
    userid,
    key_name,
-   apikey,
+   secret_hash,
    created,
    expires
 from 

--- a/schema/src/test/test_webuser_abilities.sql
+++ b/schema/src/test/test_webuser_abilities.sql
@@ -118,43 +118,15 @@ AS
 
     procedure can_interact_with_api_keys_table_and_view is
         l_userid varchar(128) := upper('&eroc.hectest');
-        l_testkey cwms_20.at_api_keys.apikey%type := 'A simple test key';
+        l_testkey cwms_20.at_api_keys.secret_hash%type := 'A simple test key';
         l_testkey_name cwms_20.at_api_keys.key_name%type := 'A test key';
         l_testkey_name_out cwms_20.at_api_keys.key_name%type;
     begin
         cwms_20.cwms_env.set_session_user_direct('&&eroc.webtest','&&office_id');
-        insert into cwms_20.at_api_keys(userid,key_name,apikey)
-            values (l_userid,l_testkey_name,l_testkey);
-        select key_name into l_testkey_name_out from cwms_20.av_active_api_keys where apikey=l_testkey;
+        insert into cwms_20.at_api_keys(key_id,userid,key_name,secret_hash)
+            values (secret_hash, l_userid,l_testkey_name,l_testkey);
+        select key_name into l_testkey_name_out from cwms_20.av_active_api_keys where secret_hash=l_testkey;
         ut.expect(l_testkey_name_out).to_equal(l_testkey_name);
-    end;
-
-
-    procedure can_set_context_user_by_key is
-        l_testkey1 cwms_20.at_api_keys.apikey%type := 'User 1 Test Key';
-        l_testkey2 cwms_20.at_api_keys.apikey%type := 'User 2 Test Key';
-        l_user1 varchar2(128) := upper('&eroc.hectest');
-        l_user2 varchar2(128) := upper('&eroc.hectest_ro');
-        l_priv varchar2(255);
-    begin
-        insert into cwms_20.at_api_keys(userid,key_name,apikey)
-            values (l_user1,l_testkey1,l_testkey1);
-        insert into cwms_20.at_api_keys(userid,key_name,apikey)
-            values (l_user2,l_testkey2,l_testkey2);
-
-        cwms_env.set_session_user_apikey(l_testkey1,'&&office_id');
-        ut.expect(cwms_util.get_user_id).to_equal(l_user1);
-
-        -- test without office ID set
-        cwms_env.set_session_user_apikey(l_testkey2);
-        ut.expect(cwms_util.get_user_id).to_equal(l_user2);
-        ut.expect(SYS_CONTEXT ('CWMS_ENV', 'CWMS_PRIVILEGE')).to_equal('READ_ONLY');
-
-        /** I don't believe it but this actually is required, which is good. But
-            we should still call it to make sure it doesn't fail.
-        */
-        cwms_env.set_session_user_direct(upper('&eroc.webtest'),'&&office_id');
-
     end;
 
     PROCEDURE test_create_cwms_cwbi_user


### PR DESCRIPTION
- this will allow for rapid lookup via CDA when attempting to check secret_hash
- also rename apikey column to secret_hash in order to explicitly call out apikeys being hashed.
- update secret hash size to 512 to be well over the bounds of argon2 hashing.
- Update to only allow moving the `EXPIRES` field backwards as we do not want to allow resurrection of expired keys
- remove uniqueness constraint on the apikey hash as collisions may be possible