### PR TITLE
Add SHOW STACK TRACE security group

### DIFF
--- a/schema/src/cwms/at_schema_sec.sql
+++ b/schema/src/cwms/at_schema_sec.sql
@@ -664,6 +664,17 @@ INSERT INTO cwms_sec_user_groups (
 												 user_group_id,
 												 user_group_desc
 			  )
+  VALUES   (
+					6,
+					'SHOW STACK TRACE',
+					'Users allowed to receive server stack traces in explicitly enabled debug responses.'
+			  );
+
+INSERT INTO cwms_sec_user_groups (
+												 user_group_code,
+												 user_group_id,
+												 user_group_desc
+			  )
   VALUES   (7, 'CWMS User Admins', 'User who administrates CWMS Users.'
 			  );
 


### PR DESCRIPTION
Used with 
- https://github.com/USACE/cwms-data-api/pull/1683

Adds a new built in CWMS security group `SHOW STACK TRACE`

Prevents using broader groups like `CWMS User Admins` which was originally used in the PR 1683 above