### PR TITLE
Reordered `pump_flow_unit` in type and related usages for consistency…

### DIFF
--- a/schema/src/cwms/cwms_water_supply_pkg_body.sql
+++ b/schema/src/cwms/cwms_water_supply_pkg_body.sql
@@ -1255,13 +1255,13 @@ BEGIN
           rec.phys_trans_type_tooltip,
           rec.phys_trans_type_active),
         rec.pump_flow * rec.factor + rec.offset,
-        nvl(p_units, 'cms'),
         -- rec.units_id,
         cwms_util.change_timezone(
            rec.transfer_start_datetime,
            'UTC',
            l_time_zone),
-        rec.accounting_remarks);
+        rec.accounting_remarks,
+        nvl(p_units, 'cms'));
    END loop;
 END retrieve_pump_accounting;
 

--- a/schema/src/cwms/types/wat_usr_contract_acct_obj_t.sql
+++ b/schema/src/cwms/types/wat_usr_contract_acct_obj_t.sql
@@ -19,9 +19,9 @@ AS
     pump_location_ref location_ref_t, --the contract pump that was used for this accounting.
     physical_transfer_type lookup_type_obj_t,         --The type of transfer for this water movement.  See AT_PHYSICAL_TRANSFER_TYPE_CODE.
     pump_flow binary_double,                  --Param: Flow. The flow associated with the water accounting record
-    pump_flow_unit varchar2(16),             -- The units used for pump_flow
     transfer_start_datetime date,                     --The date this water movement began, DATE includes the time zone.
-    accounting_remarks varchar2(255 byte)             --Any comments regarding this water accounting movement
+    accounting_remarks varchar2(255 byte),             --Any comments regarding this water accounting movement
+    pump_flow_unit varchar2(16)             -- The units used for pump_flow
   );
 /
 

--- a/schema/src/test/test_cwms_water_supply.sql
+++ b/schema/src/test/test_cwms_water_supply.sql
@@ -177,9 +177,9 @@ begin
             location_ref_t(c_pump_loc_id, c_office_id),
             lookup_type_obj_t('CWMS','Pipeline','', 'T'),
             l_flow_cfs,
-            'cfs',
             l_start_time,
-            'Roundtrip units test')
+            'Roundtrip units test',
+            'cfs')
       ),
       p_contract_ref => l_contract_ref,
       p_pump_time_window_tab => loc_ref_time_window_tab_t(


### PR DESCRIPTION
… and backwards compatability.

Resolves issue #142 where accounting data is retrieved and the parsing fails.  Related to https://jira.hecdev.net/browse/CWMS-2466.