### PR TITLE
CWMS-2464 handle null datum by returning null XML (#157)

### DIFF
--- a/schema/src/cwms/cwms_loc_pkg_body.sql
+++ b/schema/src/cwms/cwms_loc_pkg_body.sql
@@ -7882,6 +7882,11 @@ end unassign_loc_groups;
        where pl.location_code = p_location_code
          and bl.base_location_code = pl.base_location_code
          and o.office_code = bl.db_office_code;
+      l_native_datum := normalize_vertical_datum_in(l_native_datum);
+      if l_native_datum is null then
+         p_vert_datum_info := null;
+         return;
+      end if;
       l_vert_datum_info := '<vertical-datum-info office="'
          ||l_office_id
          ||'" unit="'
@@ -7893,7 +7898,6 @@ end unassign_loc_groups;
          ||dbms_xmlgen.convert(l_location_id)
          ||'</location>'
          ||chr(10);
-      l_native_datum := normalize_vertical_datum_in(l_native_datum);
       if l_native_datum not in ('NGVD29', 'NAVD88', 'LOCAL') then
          l_local_datum_name := l_native_datum;
          l_native_datum := 'LOCAL';

--- a/schema/src/test/test_cwms_loc.sql
+++ b/schema/src/test/test_cwms_loc.sql
@@ -53,6 +53,8 @@ procedure test_international_location;
 procedure test_vertical_datum_info_series_f;
 --%test(Test issue #57 - query vertical datum offset)
 procedure test_query_vertical_datum_offset;
+--%test(Test retrieval of vertical datum XML for location with null vertical datum)
+procedure test_null_vertical_datum;
 
 procedure setup;
 procedure teardown;
@@ -2734,6 +2736,37 @@ AS
       ut.expect(l_offset).to_be_not_null;
 
    end test_query_vertical_datum_offset;
+
+    --------------------------------------------------------------------------------
+    -- procedure test_null_vertical_datum
+    --------------------------------------------------------------------------------
+    procedure test_null_vertical_datum
+       is
+       l_vert_datum_info varchar2(120);
+       l_loc_id varchar2(64) := 'VANK';
+    begin
+       teardown;
+
+       cwms_loc.store_location(
+          p_location_id  => l_loc_id,
+          p_db_office_id => '&&office_id',
+          p_county_name => 'Crawford',
+          p_longitude => -94.3565139,
+          p_latitude => 35.43085,
+          p_horizontal_datum => 'NAD83',
+          p_time_zone_id => 'US/Central',
+          p_state_initial => 'AR',
+          p_public_name => 'VANK'
+       );
+
+       cwms_loc.get_vertical_datum_info(
+          p_vert_datum_info => l_vert_datum_info,
+          p_location_code   => cwms_loc.get_location_code('&&office_id', l_loc_id),
+          p_unit            => 'ft');
+       ut.expect(l_vert_datum_info).to_be_null();
+
+    end test_null_vertical_datum;
+
 END test_cwms_loc;
 /
 


### PR DESCRIPTION
* this reverts null handling to previous behavior rather than returning a mostly empty XML payload
* add ut/plsql test for null vertical datum

(cherry picked from commit ec91cd99ad01f7ce0e4e8a6ceb7cb81023eb79c1)