### PR TITLE
CDA-120: TS and Loc Group ignore_missing flag support

### DIFF
--- a/schema/src/cwms/cwms_loc_pkg.sql
+++ b/schema/src/cwms/cwms_loc_pkg.sql
@@ -182,6 +182,23 @@ AS
                               )
       RETURN NUMBER;
    /**
+    * Retrieves a location's unique numeric code
+    *
+    * @param p_db_office_id   The office that owns the location.
+    * @param p_location_id    The location identifier
+    * @param p_check_aliases  A flag ('T' or 'F') that specifies whether to check aliases if p_location_id is not found as a location identifier
+    * @param p_ignore_missing A flag ('T' or 'F') that specifies whether to ignore missing locations.
+    *                         If set to 'T', the function will return -1 when a location does not exist in the database.
+    *
+    * @return The unique numeric code that identifies the location
+    */
+   FUNCTION get_location_code (p_db_office_id     IN VARCHAR2,
+                               p_location_id      IN VARCHAR2,
+                               p_check_aliases    IN VARCHAR2,
+                               p_ignore_missing   IN VARCHAR2
+                              )
+      RETURN NUMBER;
+   /**
     * Retrieves a state's unique numeric code given its two letter state abbreviation
     *
     * @param p_state_initial The state's two letter abbreviation

--- a/schema/src/cwms/cwms_loc_pkg.sql
+++ b/schema/src/cwms/cwms_loc_pkg.sql
@@ -1616,7 +1616,7 @@ AS
     * @param p_ignore_missing    Whether to fail on location assignments for locations that are not in the database
     * @param p_missing_locations A list of locations that are not in the database and were not assigned to the group
     */
-   PROCEDURE assign_loc_groups4 (p_loc_category_id   IN VARCHAR2,
+   PROCEDURE assign_loc_groups_supports_missing (p_loc_category_id   IN VARCHAR2,
                                  p_loc_group_id 	  IN VARCHAR2,
                                  p_loc_alias_array   IN loc_alias_array3,
                                  p_db_office_id 	  IN VARCHAR2 DEFAULT NULL,

--- a/schema/src/cwms/cwms_loc_pkg.sql
+++ b/schema/src/cwms/cwms_loc_pkg.sql
@@ -1589,6 +1589,24 @@ AS
 											p_db_office_id 	  IN VARCHAR2 DEFAULT NULL
 										  );
    /**
+    * Assigns one more more locations to a location group, optionally assigning aliases, attributes, and referenced locations
+    * Can ignore locations that are not in the database when using the ignore_missing parameter
+    *
+    * @param p_loc_category_id   The location category identifier that contains the location group
+    * @param p_loc_group_id      The location group identifier
+    * @param p_loc_alias_array   The locations to assign to the group
+    * @param p_db_office_id      The office that owns the locaation category, location group, and location. If not specified or NULL, the session user's default office is used
+    * @param p_ignore_missing    Whether to fail on location assignments for locations that are not in the database
+    * @param p_missing_locations A list of locations that are not in the database and were not assigned to the group
+    */
+   PROCEDURE assign_loc_groups4 (p_loc_category_id   IN VARCHAR2,
+                                 p_loc_group_id 	  IN VARCHAR2,
+                                 p_loc_alias_array   IN loc_alias_array3,
+                                 p_db_office_id 	  IN VARCHAR2 DEFAULT NULL,
+                                 p_ignore_missing    IN VARCHAR2 DEFAULT 'F',
+                                 p_missing_locations OUT loc_alias_array3
+   );
+   /**
     * Renames a location category
     *
     * @param p_loc_category_id_old The existing location category identifier

--- a/schema/src/cwms/cwms_loc_pkg_body.sql
+++ b/schema/src/cwms/cwms_loc_pkg_body.sql
@@ -4968,6 +4968,126 @@ end get_srid;
                          l_db_office_code
                       );
    END assign_loc_groups3;
+   PROCEDURE assign_loc_groups4 (p_loc_category_id   IN VARCHAR2,
+                                 p_loc_group_id 	  IN VARCHAR2,
+                                 p_loc_alias_array   IN loc_alias_array3,
+                                 p_db_office_id 	  IN VARCHAR2 DEFAULT NULL,
+                                 p_ignore_missing    IN VARCHAR2 DEFAULT 'F',
+                                 p_missing_locations OUT loc_alias_array3
+                                )
+   IS
+      l_db_office_id         VARCHAR2 (16);
+      l_db_office_code       NUMBER;
+      l_loc_category_code    NUMBER;
+      l_loc_group_code       NUMBER;
+   BEGIN
+      p_missing_locations := loc_alias_array3();
+
+      IF p_db_office_id IS NULL
+      THEN
+         l_db_office_id := cwms_util.user_office_id;
+      ELSE
+         l_db_office_id := UPPER (p_db_office_id);
+      END IF;
+
+      l_db_office_code := cwms_util.get_office_code (l_db_office_id);
+
+      BEGIN
+         l_loc_category_code :=
+            get_loc_category_code (p_loc_category_id, l_db_office_code);
+      EXCEPTION
+         WHEN NO_DATA_FOUND
+            THEN
+               cwms_err.raise (
+                  'GENERIC_ERROR',
+                  'The category id: ' || p_loc_category_id || ' does not exist.'
+               );
+      END;
+
+      BEGIN
+         l_loc_group_code :=
+            get_loc_group_code (p_loc_category_id,
+                                p_loc_group_id,
+                                l_db_office_code
+            );
+      EXCEPTION
+         WHEN NO_DATA_FOUND
+            THEN
+               cwms_err.raise (
+                  'GENERIC_ERROR',
+                  'There is no group: '
+                     || p_loc_group_id
+                     || ' in the '
+                     || p_loc_category_id
+                     || ' category.'
+               );
+      END;
+
+      FOR i IN 1 .. p_loc_alias_array.COUNT
+         LOOP
+            BEGIN
+               check_alias_id (p_loc_alias_array (i).loc_alias_id,
+                               p_loc_alias_array (i).location_id,
+                               p_loc_category_id,
+                               p_loc_group_id,
+                               l_db_office_id
+               );
+            EXCEPTION
+               WHEN NO_DATA_FOUND
+                  THEN
+                     p_missing_locations.extend;
+                     p_missing_locations (p_missing_locations.COUNT) :=
+                        p_loc_alias_array (i);
+            END;
+         END LOOP;
+
+      MERGE INTO    at_loc_group_assignment a
+      USING    (SELECT   get_location_code (p_db_office_id => l_db_office_id, p_location_id => plaa.location_id, p_check_aliases => 'F') location_code,
+                         plaa.loc_attribute, plaa.loc_alias_id,
+                         plaa.loc_ref_id
+                FROM   TABLE (p_loc_alias_array) plaa) b
+      ON    (a.loc_group_code = l_loc_group_code
+         AND a.location_code = b.location_code)
+      WHEN MATCHED
+         THEN
+         UPDATE SET
+                   a.loc_attribute = b.loc_attribute,
+                   a.loc_alias_id = b.loc_alias_id,
+                   a.loc_ref_code =
+                      DECODE (
+                         b.loc_ref_id,
+                         NULL, NULL,
+                         get_location_code (p_db_office_code   => l_db_office_code,
+                                            p_location_id      => b.loc_ref_id,
+                                            p_check_aliases    => 'F'
+                         )
+                      )
+      WHEN NOT MATCHED
+         THEN
+         INSERT       (location_code,
+                       loc_group_code,
+                       loc_attribute,
+                       loc_alias_id,
+                       loc_ref_code,
+                       office_code
+         )
+         VALUES    (
+                      b.location_code,
+                      l_loc_group_code,
+                      b.loc_attribute,
+                      b.loc_alias_id,
+                      DECODE (
+                         b.loc_ref_id,
+                         NULL, NULL,
+                         get_location_code (
+                            p_db_office_code   => l_db_office_code,
+                            p_location_id      => b.loc_ref_id,
+                            p_check_aliases    => 'F'
+                         )
+                      ),
+                      l_db_office_code
+                   );
+   END;
 
    -- creates it and will rename the aliases if they already exist.
    PROCEDURE assign_loc_group (p_loc_category_id   IN VARCHAR2,

--- a/schema/src/cwms/cwms_loc_pkg_body.sql
+++ b/schema/src/cwms/cwms_loc_pkg_body.sql
@@ -5048,15 +5048,16 @@ end get_srid;
                       );
    END assign_loc_groups3;
    ------------------------------------------
-   -- assign_loc_groups4
+   -- assign_loc_groups_supports_missing
    ------------------------------------------
-   PROCEDURE assign_loc_groups4 (p_loc_category_id   IN VARCHAR2,
-                                 p_loc_group_id 	  IN VARCHAR2,
-                                 p_loc_alias_array   IN loc_alias_array3,
-                                 p_db_office_id 	  IN VARCHAR2 DEFAULT NULL,
-                                 p_ignore_missing    IN VARCHAR2 DEFAULT 'F',
-                                 p_missing_locations OUT loc_alias_array3
-                                )
+   PROCEDURE assign_loc_groups_supports_missing (
+      p_loc_category_id   IN VARCHAR2,
+      p_loc_group_id 	  IN VARCHAR2,
+      p_loc_alias_array   IN loc_alias_array3,
+      p_db_office_id 	  IN VARCHAR2 DEFAULT NULL,
+      p_ignore_missing    IN VARCHAR2 DEFAULT 'F',
+      p_missing_locations OUT loc_alias_array3
+     )
    IS
       l_db_office_id         VARCHAR2 (16);
       l_db_office_code       NUMBER;
@@ -5064,7 +5065,8 @@ end get_srid;
       l_loc_group_code       NUMBER;
       l_loc_code             NUMBER;
       l_existing_locs        loc_alias_array3 := loc_alias_array3();
-      l_loc_index            NUMBER := 0;
+      l_raise_missing        boolean := false;
+      l_error_message        VARCHAR2(10000) := '';
    BEGIN
       p_missing_locations := loc_alias_array3();
 
@@ -5123,21 +5125,31 @@ end get_srid;
                                   p_ignore_missing => p_ignore_missing);
                if l_loc_code = -1
                   THEN
-                     if p_ignore_missing = 'T'
+                     p_missing_locations.extend;
+                     p_missing_locations (p_missing_locations.COUNT) := p_loc_alias_array (i);
+                     if p_ignore_missing = 'F'
                         THEN
-                           p_missing_locations.extend;
-                           p_missing_locations (p_missing_locations.COUNT) :=
-                              p_loc_alias_array (i);
-                        ELSE
-                           cwms_err.raise('LOCATION_ID_NOT_FOUND', p_loc_alias_array (i).location_id);
+                           l_raise_missing := true;
                         END IF;
                   ELSE
-                     l_loc_index := l_loc_index + 1;
                      l_existing_locs.extend;
-                     l_existing_locs(l_loc_index) := p_loc_alias_array (i);
+                     l_existing_locs(l_existing_locs.count) := p_loc_alias_array (i);
                   END IF;
             END;
          END LOOP;
+
+      if l_raise_missing = true and p_missing_locations.count > 0 then
+         for k in 1..p_missing_locations.count loop
+            if LENGTH(l_error_message) = 0 THEN
+               l_error_message := p_missing_locations(k).location_id;
+            ELSE
+               l_error_message := l_error_message || ', ' || p_missing_locations(k).location_id;
+            end if;
+         end loop;
+         cwms_err.raise('ITEM_DOES_NOT_EXIST',
+                         'Location group assignments: ',
+                         l_error_message);
+      end if;
 
       MERGE INTO    at_loc_group_assignment a
       USING    (SELECT   get_location_code (p_db_office_id => l_db_office_id, p_location_id => plaa.location_id, p_check_aliases => 'F') location_code,
@@ -5185,7 +5197,7 @@ end get_srid;
                       ),
                       l_db_office_code
                    );
-   END;
+   END assign_loc_groups_supports_missing;
 
    -- creates it and will rename the aliases if they already exist.
    PROCEDURE assign_loc_group (p_loc_category_id   IN VARCHAR2,

--- a/schema/src/cwms/cwms_loc_pkg_body.sql
+++ b/schema/src/cwms/cwms_loc_pkg_body.sql
@@ -5065,7 +5065,6 @@ end get_srid;
       l_loc_group_code       NUMBER;
       l_loc_code             NUMBER;
       l_existing_locs        loc_alias_array3 := loc_alias_array3();
-      l_raise_missing        boolean := false;
       l_error_message        VARCHAR2(10000) := '';
    BEGIN
       p_missing_locations := loc_alias_array3();
@@ -5127,10 +5126,6 @@ end get_srid;
                   THEN
                      p_missing_locations.extend;
                      p_missing_locations (p_missing_locations.COUNT) := p_loc_alias_array (i);
-                     if p_ignore_missing = 'F'
-                        THEN
-                           l_raise_missing := true;
-                        END IF;
                   ELSE
                      l_existing_locs.extend;
                      l_existing_locs(l_existing_locs.count) := p_loc_alias_array (i);
@@ -5138,7 +5133,7 @@ end get_srid;
             END;
          END LOOP;
 
-      if l_raise_missing = true and p_missing_locations.count > 0 then
+      if p_ignore_missing = 'F' and p_missing_locations.count > 0 then
          for k in 1..p_missing_locations.count loop
             if LENGTH(l_error_message) = 0 THEN
                l_error_message := p_missing_locations(k).location_id;

--- a/schema/src/cwms/cwms_loc_pkg_body.sql
+++ b/schema/src/cwms/cwms_loc_pkg_body.sql
@@ -203,6 +203,85 @@ AS
          RAISE;
    END get_location_code;
 
+   FUNCTION get_location_code (p_db_office_id     IN VARCHAR2,
+                               p_location_id      IN VARCHAR2,
+                               p_check_aliases    IN VARCHAR2,
+                               p_ignore_missing   IN VARCHAR2
+   )
+      RETURN NUMBER
+      IS
+      l_location_code   NUMBER;
+      l_cache_id        varchar2(271);
+      l_db_office_code    NUMBER := cwms_util.get_office_code (p_db_office_id);
+   BEGIN
+      IF p_location_id IS NULL
+      THEN
+         cwms_err.raise ('ERROR',
+                         'The P_LOCATION_ID parameter cannot be NULL'
+         );
+      END IF;
+
+      --
+      l_cache_id := to_char(l_db_office_code)||'/'||upper(p_location_id);
+      l_location_code := cwms_cache.get(g_location_code_cache, l_cache_id);
+      if l_location_code is not null then
+         return l_location_code;
+      end if;
+
+      SELECT   apl.location_code
+      INTO   l_location_code
+      FROM   at_physical_location apl, at_base_location abl
+      WHERE   apl.base_location_code = abl.base_location_code
+        AND UPPER (abl.base_location_id) =
+            UPPER (cwms_util.get_base_id (p_location_id))
+        AND NVL (UPPER (apl.sub_location_id), '.') =
+            NVL (UPPER (cwms_util.get_sub_id (p_location_id)), '.')
+        AND abl.db_office_code = l_db_office_code;
+
+      --
+      cwms_cache.put(g_location_code_cache, l_cache_id, l_location_code);
+      RETURN l_location_code;
+      --
+   EXCEPTION
+      WHEN NO_DATA_FOUND
+         THEN
+            IF cwms_util.is_true(p_check_aliases) THEN
+               DECLARE
+                  l_office_id   VARCHAR2 (16);
+               BEGIN
+                  SELECT   office_id
+                  INTO   l_office_id
+                  FROM   cwms_office
+                  WHERE   office_code = l_db_office_code;
+
+                  l_location_code :=
+                     get_location_code_from_alias (p_alias_id  => p_location_id,
+                                                   p_office_id => l_office_id
+                     );
+                  IF l_location_code IS NULL
+                  THEN
+                     if p_ignore_missing = 'T' then
+                        return -1;
+                     else
+                        cwms_err.raise('LOCATION_ID_NOT_FOUND', p_location_id);
+                     end if;
+                  END IF;
+
+                  cwms_cache.put(g_location_code_cache, l_cache_id, l_location_code);
+                  RETURN l_location_code;
+               END;
+            ELSE
+               if p_ignore_missing = 'T' then
+                  return -1;
+               else
+                  RAISE;
+               end if;
+            END IF;
+      WHEN OTHERS
+         THEN
+            RAISE;
+   END get_location_code;
+
    FUNCTION get_location_code (p_db_office_code   IN NUMBER,
                                p_location_id      IN VARCHAR2
                               )
@@ -4968,6 +5047,9 @@ end get_srid;
                          l_db_office_code
                       );
    END assign_loc_groups3;
+   ------------------------------------------
+   -- assign_loc_groups4
+   ------------------------------------------
    PROCEDURE assign_loc_groups4 (p_loc_category_id   IN VARCHAR2,
                                  p_loc_group_id 	  IN VARCHAR2,
                                  p_loc_alias_array   IN loc_alias_array3,
@@ -4980,6 +5062,9 @@ end get_srid;
       l_db_office_code       NUMBER;
       l_loc_category_code    NUMBER;
       l_loc_group_code       NUMBER;
+      l_loc_code             NUMBER;
+      l_existing_locs        loc_alias_array3 := loc_alias_array3();
+      l_loc_index            NUMBER := 0;
    BEGIN
       p_missing_locations := loc_alias_array3();
 
@@ -5032,12 +5117,25 @@ end get_srid;
                                p_loc_group_id,
                                l_db_office_id
                );
-            EXCEPTION
-               WHEN NO_DATA_FOUND
+               l_loc_code := get_location_code (p_db_office_id => l_db_office_id,
+                                  p_location_id => p_loc_alias_array (i).location_id,
+                                  p_check_aliases => 'T',
+                                  p_ignore_missing => p_ignore_missing);
+               if l_loc_code = -1
                   THEN
-                     p_missing_locations.extend;
-                     p_missing_locations (p_missing_locations.COUNT) :=
-                        p_loc_alias_array (i);
+                     if p_ignore_missing = 'T'
+                        THEN
+                           p_missing_locations.extend;
+                           p_missing_locations (p_missing_locations.COUNT) :=
+                              p_loc_alias_array (i);
+                        ELSE
+                           cwms_err.raise('LOCATION_ID_NOT_FOUND', p_loc_alias_array (i).location_id);
+                        END IF;
+                  ELSE
+                     l_loc_index := l_loc_index + 1;
+                     l_existing_locs.extend;
+                     l_existing_locs(l_loc_index) := p_loc_alias_array (i);
+                  END IF;
             END;
          END LOOP;
 
@@ -5045,7 +5143,7 @@ end get_srid;
       USING    (SELECT   get_location_code (p_db_office_id => l_db_office_id, p_location_id => plaa.location_id, p_check_aliases => 'F') location_code,
                          plaa.loc_attribute, plaa.loc_alias_id,
                          plaa.loc_ref_id
-                FROM   TABLE (p_loc_alias_array) plaa) b
+                FROM   TABLE (l_existing_locs) plaa) b
       ON    (a.loc_group_code = l_loc_group_code
          AND a.location_code = b.location_code)
       WHEN MATCHED

--- a/schema/src/cwms/cwms_ts_pkg.sql
+++ b/schema/src/cwms/cwms_ts_pkg.sql
@@ -198,6 +198,22 @@ AS
                          p_db_office_id   IN VARCHAR2)
       RETURN NUMBER;
 
+  /**
+   * Retrieves the unique numeric code value for a time series
+   *
+   * @see view av_cwms_ts_id
+   *
+   * @param p_cwms_ts_id   The time series identifier
+   * @param p_db_office_id The office owning the time series
+   * @param p_fail_on_missing A value ('T' or 'F') indicating whether to fail if the time series is not found.
+   *
+   * @return  the unique numeric code value for the specified time series. -1 if the time series is not found and p_fail_on_missing is 'F'.
+   */
+   FUNCTION get_ts_code (p_cwms_ts_id      IN VARCHAR2,
+                         p_db_office_code  IN NUMBER,
+                         p_fail_on_missing IN VARCHAR2)
+      RETURN NUMBER;
+
    /**
     * Retrieves the time series identifier from its unique numeric code
     *
@@ -3151,6 +3167,29 @@ AS
                                p_ts_group_id      IN VARCHAR2,
                                p_ts_alias_array   IN ts_alias_tab_t,
                                p_db_office_id     IN VARCHAR2 DEFAULT NULL);
+
+   /**
+    * Assigns a single time series to a time series group
+    * Can ignore time series assignment that is not in the database when using the ignore_missing parameter
+    *
+    * @param p_ts_category_id The time series category that owns the time series group
+    * @param p_ts_group_id    The time series group identifier
+    * @param p_ts_alias_array The time series identifiers and associated information to assign to the group
+    * @param p_db_office_id   The office that owns the time series category, time series group and time series. If not specified or NULL, the session user's default office is used.
+    * @param p_ignore_missing A flag ('T' or 'F') that specifies whether to ignore time series assignments that are not in the database
+    * @param p_stored_ts      Whether the operation was successful (used for determining whether to mark the passed time series as a missing record)
+    */
+   PROCEDURE assign_ts_group (
+      p_ts_category_id   IN VARCHAR2,
+      p_ts_group_id      IN VARCHAR2,
+      p_ts_id            IN VARCHAR2,
+      p_ts_attribute     IN NUMBER DEFAULT NULL,
+      p_ts_alias_id      IN VARCHAR2 DEFAULT NULL,
+      p_ref_ts_id        IN VARCHAR2 DEFAULT NULL,
+      p_db_office_id     IN VARCHAR2 DEFAULT NULL,
+      p_ignore_missing   IN VARCHAR2 DEFAULT 'F',
+      p_assigned         OUT VARCHAR2
+   );
 
    /**
     * Assigns a collection of time series to a time series group

--- a/schema/src/cwms/cwms_ts_pkg.sql
+++ b/schema/src/cwms/cwms_ts_pkg.sql
@@ -3153,6 +3153,24 @@ AS
                                p_db_office_id     IN VARCHAR2 DEFAULT NULL);
 
    /**
+    * Assigns a collection of time series to a time series group
+    * Can ignore time series assignments that are not in the database when using the ignore_missing parameter
+    *
+    * @param p_ts_category_id The time series category that owns the time series group
+    * @param p_ts_group_id    The time series group identifier
+    * @param p_ts_alias_array The time series identifiers and associated information to assign to the group
+    * @param p_db_office_id   The office that owns the time series category, time series group and time series. If not specified or NULL, the session user's default office is used.
+    * @param p_ignore_missing A flag ('T' or 'F') that specifies whether to ignore time series assignments that are not in the database
+    * @param p_missing_ts     The time series identifiers for any assignments that are not in the database.
+    */
+   PROCEDURE assign_ts_groups2 (p_ts_category_id   IN VARCHAR2,
+                               p_ts_group_id      IN VARCHAR2,
+                               p_ts_alias_array   IN ts_alias_tab_t,
+                               p_db_office_id     IN VARCHAR2 DEFAULT NULL,
+                               p_ignore_missing   IN VARCHAR2 DEFAULT 'F',
+                               p_missing_ts       OUT ts_alias_tab_t);
+
+   /**
     * Un-assigns a collection of time series from a time series group
     *
     * @param p_ts_category_id The time series category that owns the time series group

--- a/schema/src/cwms/cwms_ts_pkg.sql
+++ b/schema/src/cwms/cwms_ts_pkg.sql
@@ -3179,7 +3179,7 @@ AS
     * @param p_ignore_missing A flag ('T' or 'F') that specifies whether to ignore time series assignments that are not in the database
     * @param p_stored_ts      Whether the operation was successful (used for determining whether to mark the passed time series as a missing record)
     */
-   PROCEDURE assign_ts_group (
+   PROCEDURE assign_ts_group_support_missing (
       p_ts_category_id   IN VARCHAR2,
       p_ts_group_id      IN VARCHAR2,
       p_ts_id            IN VARCHAR2,
@@ -3202,7 +3202,7 @@ AS
     * @param p_ignore_missing A flag ('T' or 'F') that specifies whether to ignore time series assignments that are not in the database
     * @param p_missing_ts     The time series identifiers for any assignments that are not in the database.
     */
-   PROCEDURE assign_ts_groups2 (p_ts_category_id   IN VARCHAR2,
+   PROCEDURE assign_ts_groups_support_missing (p_ts_category_id   IN VARCHAR2,
                                p_ts_group_id      IN VARCHAR2,
                                p_ts_alias_array   IN ts_alias_tab_t,
                                p_db_office_id     IN VARCHAR2 DEFAULT NULL,

--- a/schema/src/cwms/cwms_ts_pkg_body.sql
+++ b/schema/src/cwms/cwms_ts_pkg_body.sql
@@ -10774,7 +10774,7 @@ end retrieve_existing_item_counts;
       end if;
    end assign_ts_group;
 
-   PROCEDURE assign_ts_group (
+   PROCEDURE assign_ts_group_support_missing (
       p_ts_category_id   IN VARCHAR2,
       p_ts_group_id      IN VARCHAR2,
       p_ts_id            IN VARCHAR2,
@@ -10878,7 +10878,7 @@ end retrieve_existing_item_counts;
          INSERT INTO at_ts_group_assignment
          VALUES l_rec;
       END IF;
-   END assign_ts_group;
+   END assign_ts_group_support_missing;
 
    PROCEDURE unassign_ts_group (p_ts_category_id   IN VARCHAR2,
                                 p_ts_group_id      IN VARCHAR2,
@@ -10953,7 +10953,7 @@ end retrieve_existing_item_counts;
       END IF;
    END assign_ts_groups;
 
-   PROCEDURE assign_ts_groups2 (p_ts_category_id   IN VARCHAR2,
+   PROCEDURE assign_ts_groups_support_missing (p_ts_category_id   IN VARCHAR2,
                                 p_ts_group_id      IN VARCHAR2,
                                 p_ts_alias_array   IN ts_alias_tab_t,
                                 p_db_office_id     IN VARCHAR2 DEFAULT NULL,
@@ -10969,7 +10969,7 @@ end retrieve_existing_item_counts;
          FOR i IN 1 .. p_ts_alias_array.COUNT
             LOOP
                BEGIN
-                  cwms_ts.assign_ts_group (p_ts_category_id,
+                  cwms_ts.assign_ts_group_support_missing (p_ts_category_id,
                                            p_ts_group_id,
                                            p_ts_alias_array (i).ts_id,
                                            p_ts_alias_array (i).ts_attribute,
@@ -10998,7 +10998,7 @@ end retrieve_existing_item_counts;
                             l_error_message);
          END IF;
       END IF;
-   END assign_ts_groups2;
+   END assign_ts_groups_support_missing;
 
    PROCEDURE unassign_ts_groups (p_ts_category_id   IN VARCHAR2,
                                  p_ts_group_id      IN VARCHAR2,

--- a/schema/src/cwms/cwms_ts_pkg_body.sql
+++ b/schema/src/cwms/cwms_ts_pkg_body.sql
@@ -10808,6 +10808,50 @@ end retrieve_existing_item_counts;
       END IF;
    END assign_ts_groups;
 
+   PROCEDURE assign_ts_groups2 (p_ts_category_id   IN VARCHAR2,
+                                p_ts_group_id      IN VARCHAR2,
+                                p_ts_alias_array   IN ts_alias_tab_t,
+                                p_db_office_id     IN VARCHAR2 DEFAULT NULL,
+                                p_ignore_missing   IN VARCHAR2 DEFAULT 'F',
+                                p_missing_ts       OUT ts_alias_tab_t)
+   IS
+      l_error_message VARCHAR2(10000);
+   BEGIN
+      p_missing_ts := ts_alias_tab_t();
+      IF p_ts_alias_array IS NOT NULL
+      THEN
+         FOR i IN 1 .. p_ts_alias_array.COUNT
+            LOOP
+               BEGIN
+                  cwms_ts.assign_ts_group (p_ts_category_id,
+                                           p_ts_group_id,
+                                           p_ts_alias_array (i).ts_id,
+                                           p_ts_alias_array (i).ts_attribute,
+                                           p_ts_alias_array (i).ts_alias_id,
+                                           p_ts_alias_array (i).ts_ref_id,
+                                           p_db_office_id);
+               EXCEPTION
+                  when no_data_found then
+                     p_missing_ts.extend;
+                     p_missing_ts(p_missing_ts.count) := p_ts_alias_array(i);
+               END;
+            END LOOP;
+         IF p_missing_ts.count > 0 AND p_ignore_missing = 'F' THEN
+            FOR j in 1..p_missing_ts.count
+               LOOP
+                  IF LENGTH(l_error_message) = 0 THEN
+                     l_error_message := p_missing_ts(j).ts_id;
+                  ELSE
+                     l_error_message := l_error_message || ', ' || p_missing_ts(j).ts_id;
+                  END IF;
+               END LOOP;
+            cwms_err.raise ('ITEM_DOES_NOT_EXIST',
+                            'Time series group assignments: ',
+                            l_error_message);
+         END IF;
+      END IF;
+   END assign_ts_groups2;
+
    PROCEDURE unassign_ts_groups (p_ts_category_id   IN VARCHAR2,
                                  p_ts_group_id      IN VARCHAR2,
                                  p_ts_array         IN str_tab_t,

--- a/schema/src/cwms/cwms_ts_pkg_body.sql
+++ b/schema/src/cwms/cwms_ts_pkg_body.sql
@@ -103,6 +103,45 @@ AS
       return l_cwms_ts_code;
    end get_ts_code;
 
+   FUNCTION get_ts_code (
+      p_cwms_ts_id      IN VARCHAR2,
+      p_db_office_code  IN NUMBER,
+      p_fail_on_missing IN VARCHAR2)
+      RETURN NUMBER
+   IS
+      l_office_id    VARCHAR2(16) := cwms_util.get_db_office_id_from_code(p_db_office_code);
+      l_cwms_ts_code NUMBER;
+      l_cache_key    VARCHAR2(32767) := p_db_office_code||'/'||upper(p_cwms_ts_id);
+      l_cwms_ts_id   at_cwms_ts_id.cwms_ts_id%type;
+   BEGIN
+      validate_ts_id(p_cwms_ts_id);
+      l_cwms_ts_code := cwms_cache.get(g_ts_code_cache, l_cache_key);
+      IF l_cwms_ts_code IS NULL THEN
+         l_cwms_ts_id := format_lrts_input(
+            get_cwms_ts_id(p_cwms_ts_id, l_office_id),
+            require_new_lrts_format_on_input = 'T' or allow_new_lrts_format_on_input = 'T');
+         BEGIN
+            SELECT ts_code
+            INTO l_cwms_ts_code
+            FROM at_cwms_ts_id
+            WHERE upper(cwms_ts_id) = upper(l_cwms_ts_id)
+              AND db_office_code = p_db_office_code;
+         EXCEPTION
+            WHEN no_data_found THEN
+               IF p_fail_on_missing = 'T' THEN
+                  cwms_err.raise (
+                     'TS_ID_NOT_FOUND',
+                     trim (p_cwms_ts_id),
+                     l_office_id);
+               ELSE
+                  RETURN -1;
+               END IF;
+         END;
+         cwms_cache.put(g_ts_code_cache, l_cache_key, l_cwms_ts_code);
+      END IF;
+      RETURN l_cwms_ts_code;
+   END get_ts_code;
+
    ---------------------------------------------------------------------------
 
    FUNCTION get_ts_id (p_ts_code IN NUMBER)
@@ -10735,6 +10774,112 @@ end retrieve_existing_item_counts;
       end if;
    end assign_ts_group;
 
+   PROCEDURE assign_ts_group (
+      p_ts_category_id   IN VARCHAR2,
+      p_ts_group_id      IN VARCHAR2,
+      p_ts_id            IN VARCHAR2,
+      p_ts_attribute     IN NUMBER DEFAULT NULL,
+      p_ts_alias_id      IN VARCHAR2 DEFAULT NULL,
+      p_ref_ts_id        IN VARCHAR2 DEFAULT NULL,
+      p_db_office_id     IN VARCHAR2 DEFAULT NULL,
+      p_ignore_missing   IN VARCHAR2 DEFAULT 'F',
+      p_assigned         OUT VARCHAR2
+   )
+   IS
+      l_office_code     NUMBER(14);
+      l_ts_group_code   NUMBER(14);
+      l_ts_code         NUMBER(14);
+      l_ts_ref_code     NUMBER(14);
+      l_rec             at_ts_group_assignment%rowtype;
+      l_exists          BOOLEAN;
+      l_fail_on_missing VARCHAR2(1);
+   BEGIN
+      -------------------
+      -- sanity checks --
+      -------------------
+      l_office_code := cwms_util.get_db_office_code(p_db_office_id);
+      validate_ts_id(p_ts_id);
+      IF p_ref_ts_id IS NOT NULL THEN
+         validate_ts_id(p_ref_ts_id);
+      END IF;
+
+      IF p_ignore_missing = 'T' THEN
+         l_fail_on_missing := 'F';
+      ELSE
+         l_fail_on_missing := 'T';
+      END IF;
+
+      ------------------------
+      -- get the group code --
+      ------------------------
+      BEGIN
+         SELECT ts_group_code
+         INTO l_ts_group_code
+         FROM at_ts_category c, at_ts_group g
+         WHERE upper(c.ts_category_id) = upper(p_ts_category_id)
+           AND upper(g.ts_group_id) = upper(p_ts_group_id)
+           AND g.ts_category_code = c.ts_category_code
+           AND g.db_office_code IN (l_office_code, cwms_util.db_office_code_all);
+      EXCEPTION
+         WHEN no_data_found
+            THEN
+               cwms_err.raise(
+                  'ITEM_DOES_NOT_EXIST',
+                  'Time series group',
+                  p_ts_category_id || '/' || p_ts_group_id);
+      END;
+
+      -----------------------------------------------
+      -- determine if an assignment already exists --
+      -----------------------------------------------
+      l_ts_code := get_ts_code(p_ts_id, l_office_code, l_fail_on_missing);
+
+      if p_ref_ts_id IS NOT NULL THEN
+         l_ts_ref_code := get_ts_code(p_ref_ts_id, l_office_code, l_fail_on_missing);
+      END IF;
+
+      IF p_ignore_missing = 'T' AND (l_ts_code = -1 OR l_ts_ref_code = -1) THEN
+         p_assigned := 'F';
+         return;
+      END IF;
+
+      BEGIN
+         SELECT *
+         INTO l_rec
+         FROM at_ts_group_assignment
+         WHERE ts_code = l_ts_code AND ts_group_code = l_ts_group_code;
+
+         l_exists := true;
+      EXCEPTION
+         WHEN no_data_found THEN
+            l_exists := false;
+      END;
+
+      ------------------------
+      -- prepare the record --
+      ------------------------
+      l_rec.ts_attribute := nvl(p_ts_attribute, l_rec.ts_attribute);
+      l_rec.ts_alias_id  := nvl(p_ts_alias_id, l_rec.ts_alias_id);
+      l_rec.ts_ref_code  := nvl(l_ts_ref_code, l_rec.ts_ref_code);
+      l_rec.office_code  := l_office_code;
+
+      ---------------------------------
+      -- insert or update the record --
+      ---------------------------------
+      IF l_exists THEN
+         UPDATE at_ts_group_assignment
+         SET ROW = l_rec
+         WHERE ts_code = l_rec.ts_code
+           AND ts_group_code = l_rec.ts_group_code;
+      ELSE
+         l_rec.ts_code := l_ts_code;
+         l_rec.ts_group_code := l_ts_group_code;
+
+         INSERT INTO at_ts_group_assignment
+         VALUES l_rec;
+      END IF;
+   END assign_ts_group;
+
    PROCEDURE unassign_ts_group (p_ts_category_id   IN VARCHAR2,
                                 p_ts_group_id      IN VARCHAR2,
                                 p_ts_id            IN VARCHAR2,
@@ -10816,6 +10961,7 @@ end retrieve_existing_item_counts;
                                 p_missing_ts       OUT ts_alias_tab_t)
    IS
       l_error_message VARCHAR2(10000);
+      l_assigned VARCHAR2(1);
    BEGIN
       p_missing_ts := ts_alias_tab_t();
       IF p_ts_alias_array IS NOT NULL
@@ -10829,11 +10975,13 @@ end retrieve_existing_item_counts;
                                            p_ts_alias_array (i).ts_attribute,
                                            p_ts_alias_array (i).ts_alias_id,
                                            p_ts_alias_array (i).ts_ref_id,
-                                           p_db_office_id);
-               EXCEPTION
-                  when no_data_found then
+                                           p_db_office_id,
+                                           p_ignore_missing,
+                                           l_assigned);
+                  IF l_assigned = 'F' THEN
                      p_missing_ts.extend;
                      p_missing_ts(p_missing_ts.count) := p_ts_alias_array(i);
+                  END IF;
                END;
             END LOOP;
          IF p_missing_ts.count > 0 AND p_ignore_missing = 'F' THEN

--- a/schema/src/test/test_cwms_loc.sql
+++ b/schema/src/test/test_cwms_loc.sql
@@ -62,6 +62,11 @@ procedure test_av_loc2_text_search;
 procedure test_null_vertical_datum;
 --%test(CWMS-2430 [DB #54] Change lat/lon to generic geometry)
 procedure test_mods_for_generic_geometry;
+--%test (Test location group assignment with ignore missing flag set to true)
+procedure test_assign_loc_ignore_missing;
+--%test (Test location group assignment with ignore missing flag set to false)
+--%throws(-20025)
+procedure test_assign_loc_do_not_ignore_missing;
 
 procedure setup;
 procedure teardown;
@@ -3697,6 +3702,56 @@ AS
       end loop;
       commit;
    end test_mods_for_generic_geometry;
+
+   PROCEDURE test_assign_loc_ignore_missing
+   IS
+      l_loc_aliases loc_alias_array3 := loc_alias_array3();
+      l_missing_locs loc_alias_array3;
+      l_stored_loc VARCHAR2(12) := 'TestLocation';
+      l_non_existent_location VARCHAR2(11) := 'NotARealLoc';
+      l_office_id VARCHAR2(3) := '&&office_id';
+   BEGIN
+      cwms_loc.store_location (p_location_id    => l_stored_loc,
+                               p_db_office_id   => l_office_id);
+      cwms_loc.STORE_LOC_CATEGORY('TestCategory', 'A test category', l_office_id);
+      cwms_loc.store_loc_group('TestCategory', 'TestGroup', 'Unit Test Group',
+                               'F', 'T', null, null, l_office_id);
+
+      l_loc_aliases.extend;
+      l_loc_aliases(1) := loc_alias_type3(l_stored_loc, null, null, null);
+
+      l_loc_aliases.extend;
+      l_loc_aliases(2) := loc_alias_type3(l_non_existent_location, null, null, null);
+
+      cwms_loc.assign_loc_groups4('TestCategory', 'TestGroup', l_loc_aliases, l_office_id, 'T', l_missing_locs);
+
+      ut.expect(l_missing_locs.count).to_equal(1);
+      ut.expect(l_missing_locs(1).location_id).to_equal(l_non_existent_location);
+
+      cwms_loc.delete_loc_group('TestCategory', 'TestGroup', 'T', l_office_id);
+   END;
+
+   PROCEDURE test_assign_loc_do_not_ignore_missing
+   IS
+      l_loc_aliases loc_alias_array3 := loc_alias_array3();
+      l_missing_locs loc_alias_array3;
+      l_stored_loc VARCHAR2(12) := 'TestLocation';
+      l_non_existent_location VARCHAR2(11) := 'NotARealLoc';
+      l_office_id VARCHAR2(3) := '&&office_id';
+   BEGIN
+      cwms_loc.store_location (p_location_id    => l_stored_loc,
+                               p_db_office_id   => l_office_id);
+      cwms_loc.STORE_LOC_CATEGORY('TestCategory', 'A test category', l_office_id);
+      cwms_loc.store_loc_group('TestCategory', 'TestGroup', 'Unit Test Group',
+                               'F', 'T', null, null, l_office_id);
+      l_loc_aliases.extend;
+      l_loc_aliases(1) := loc_alias_type3(l_stored_loc, null, null, null);
+
+      l_loc_aliases.extend;
+      l_loc_aliases(2) := loc_alias_type3(l_non_existent_location, null, null, null);
+
+      cwms_loc.assign_loc_groups4('TestCategory', 'TestGroup', l_loc_aliases, l_office_id, 'F', l_missing_locs);
+   END;
 END test_cwms_loc;
 /
 show errors;

--- a/schema/src/test/test_cwms_loc.sql
+++ b/schema/src/test/test_cwms_loc.sql
@@ -65,7 +65,6 @@ procedure test_mods_for_generic_geometry;
 --%test (Test location group assignment with ignore missing flag set to true)
 procedure test_assign_loc_ignore_missing;
 --%test (Test location group assignment with ignore missing flag set to false)
---%throws(-20025)
 procedure test_assign_loc_do_not_ignore_missing;
 
 procedure setup;
@@ -3723,7 +3722,7 @@ AS
       l_loc_aliases.extend;
       l_loc_aliases(2) := loc_alias_type3(l_non_existent_location, null, null, null);
 
-      cwms_loc.assign_loc_groups4('TestCategory', 'TestGroup', l_loc_aliases, l_office_id, 'T', l_missing_locs);
+      cwms_loc.assign_loc_groups_supports_missing('TestCategory', 'TestGroup', l_loc_aliases, l_office_id, 'T', l_missing_locs);
 
       ut.expect(l_missing_locs.count).to_equal(1);
       ut.expect(l_missing_locs(1).location_id).to_equal(l_non_existent_location);
@@ -3750,7 +3749,10 @@ AS
       l_loc_aliases.extend;
       l_loc_aliases(2) := loc_alias_type3(l_non_existent_location, null, null, null);
 
-      cwms_loc.assign_loc_groups4('TestCategory', 'TestGroup', l_loc_aliases, l_office_id, 'F', l_missing_locs);
+      cwms_loc.assign_loc_groups_supports_missing('TestCategory', 'TestGroup', l_loc_aliases, l_office_id, 'F', l_missing_locs);
+      EXCEPTION
+         WHEN OTHERS then
+            ut.expect(sqlerrm).to_be_like('%' || l_non_existent_location || '%');
    END;
 END test_cwms_loc;
 /

--- a/schema/src/test/test_cwms_ts.sql
+++ b/schema/src/test/test_cwms_ts.sql
@@ -144,7 +144,6 @@ procedure test_ts_categories;
 procedure test_assign_ts_ignore_missing;
 
 --%test (Test TS group assignment with ignore missing flag set to false)
---%throws(-20001)
 procedure test_assign_ts_do_not_ignore_missing;
 
 test_base_location_id VARCHAR2(32) := 'TestLoc1';
@@ -4625,7 +4624,7 @@ AS
       cwms_ts.store_ts_group('TestCategory', 'TestGroup', 'Group for unit tests', 'F', 'T', null, null, '&&office_id');
 
       -- Assign TS to group
-      cwms_ts.assign_ts_groups2('TestCategory', 'TestGroup', l_ts_assign, '&&office_id', 'T', l_results);
+      cwms_ts.assign_ts_groups_support_missing('TestCategory', 'TestGroup', l_ts_assign, '&&office_id', 'T', l_results);
 
       -- Verify assignment exists
       select count(*) into l_count
@@ -4676,7 +4675,10 @@ AS
       cwms_ts.store_ts_group('TestCategory', 'TestGroup', 'Group for unit tests', 'F', 'T', null, null, '&&office_id');
 
       -- Assign TS to group
-      cwms_ts.assign_ts_groups2('TestCategory', 'TestGroup', l_ts_assign, '&&office_id', 'F', l_results);
+      cwms_ts.assign_ts_groups_support_missing('TestCategory', 'TestGroup', l_ts_assign, '&&office_id', 'F', l_results);
+      exception
+         when OTHERS then
+            ut.expect(sqlerrm).to_be_like('%' || l_bad_ts_id || '%');
    end test_assign_ts_do_not_ignore_missing;
 
 END test_cwms_ts;

--- a/schema/src/test/test_cwms_ts.sql
+++ b/schema/src/test/test_cwms_ts.sql
@@ -4615,7 +4615,7 @@ AS
 
       -- Add invalid TS assignment
       l_ts_assign.extend;
-      l_ts_assign(1) := ts_alias_t(ts_id => l_bad_ts_id,
+      l_ts_assign(2) := ts_alias_t(ts_id => l_bad_ts_id,
                                    ts_attribute => null,
                                    ts_alias_id => null,
                                    ts_ref_id => null);

--- a/schema/src/test/test_cwms_ts.sql
+++ b/schema/src/test/test_cwms_ts.sql
@@ -140,6 +140,13 @@ procedure test_delete_ts_group_cascade;
 --%test (Test existence of expected time series categories)
 procedure test_ts_categories;
 
+--%test (Test TS group assignment with ignore missing flag set to true)
+procedure test_assign_ts_ignore_missing;
+
+--%test (Test TS group assignment with ignore missing flag set to false)
+--%throws(-20001)
+procedure test_assign_ts_do_not_ignore_missing;
+
 test_base_location_id VARCHAR2(32) := 'TestLoc1';
 test_withsub_location_id VARCHAR2(32) := test_base_location_id||'-withsub';
 test_renamed_base_location_id VARCHAR2(32) := 'RenameTestLoc1';
@@ -4584,6 +4591,93 @@ AS
       ut.expect(l_count).to_equal(l_expected_categories.count);
 
    end test_ts_categories;
+
+   ---------------------------------------------------------------------------------
+   -- procedure test_assign_ts_ignore_missing
+   ---------------------------------------------------------------------------------
+   procedure test_assign_ts_ignore_missing
+   is
+      l_count integer;
+      l_ts_id varchar2(200) := test_base_location_id||'.Flow.Inst.1Hour.0.Test2';
+      l_results ts_alias_tab_t;
+      l_ts_assign ts_alias_tab_t := ts_alias_tab_t();
+      l_bad_ts_id varchar(200) := test_base_location_id||'.Flow.Inst.1Hour.0.Test3';
+   begin
+      setup;
+      cwms_ts.create_ts('&&office_id', l_ts_id);
+
+      -- Add ts assignment
+      l_ts_assign.extend;
+      l_ts_assign(1) := ts_alias_t(ts_id => l_ts_id,
+                                   ts_attribute => null,
+                                   ts_alias_id => null,
+                                   ts_ref_id => null);
+
+      -- Add invalid TS assignment
+      l_ts_assign.extend;
+      l_ts_assign(1) := ts_alias_t(ts_id => l_bad_ts_id,
+                                   ts_attribute => null,
+                                   ts_alias_id => null,
+                                   ts_ref_id => null);
+
+      -- Create a test category and group
+      cwms_ts.store_ts_category('TestCategory', 'Category for unit tests', '&&office_id');
+      cwms_ts.store_ts_group('TestCategory', 'TestGroup', 'Group for unit tests', 'F', 'T', null, null, '&&office_id');
+
+      -- Assign TS to group
+      cwms_ts.assign_ts_groups2('TestCategory', 'TestGroup', l_ts_assign, '&&office_id', 'T', l_results);
+
+      -- Verify assignment exists
+      select count(*) into l_count
+      from at_ts_group_assignment
+      where ts_group_code = (select ts_group_code
+                             from at_ts_group
+                             where ts_category_code = (select ts_category_code
+                                                       from at_ts_category
+                                                       where db_office_code = cwms_util.get_office_code('&&office_id')
+                                                         and upper(ts_category_id) = 'TESTCATEGORY')
+                               and upper(ts_group_id) = 'TESTGROUP');
+      ut.expect(l_count).to_equal(1);
+
+      ut.expect(l_results.count).to_equal(1);
+      ut.expect(l_results(1).ts_id).to_equal(l_bad_ts_id);
+   end test_assign_ts_ignore_missing;
+
+   ---------------------------------------------------------------------------------
+   -- procedure test_assign_ts_do_not_ignore_missing
+   ---------------------------------------------------------------------------------
+   procedure test_assign_ts_do_not_ignore_missing
+   is
+      l_count integer;
+      l_ts_id varchar2(200) := test_base_location_id||'.Flow.Inst.1Hour.0.Test2';
+      l_results ts_alias_tab_t;
+      l_ts_assign ts_alias_tab_t := ts_alias_tab_t();
+      l_bad_ts_id varchar(200) := test_base_location_id|| '.Flow.Inst.1Hour.0.Test3';
+   begin
+      setup;
+      cwms_ts.create_ts('&&office_id', l_ts_id);
+
+      -- Add ts assignment
+      l_ts_assign.extend;
+      l_ts_assign(1) := ts_alias_t(ts_id => l_ts_id,
+                         ts_attribute => null,
+                         ts_alias_id => null,
+                         ts_ref_id => null);
+
+      -- Add invalid TS assignment
+      l_ts_assign.extend;
+      l_ts_assign(1) := ts_alias_t(ts_id => l_bad_ts_id,
+                                 ts_attribute => null,
+                                 ts_alias_id => null,
+                                 ts_ref_id => null);
+
+      -- Create a test category and group
+      cwms_ts.store_ts_category('TestCategory', 'Category for unit tests', '&&office_id');
+      cwms_ts.store_ts_group('TestCategory', 'TestGroup', 'Group for unit tests', 'F', 'T', null, null, '&&office_id');
+
+      -- Assign TS to group
+      cwms_ts.assign_ts_groups2('TestCategory', 'TestGroup', l_ts_assign, '&&office_id', 'F', l_results);
+   end test_assign_ts_do_not_ignore_missing;
 
 END test_cwms_ts;
 /


### PR DESCRIPTION
Includes new procedures for TS group and Location group assignment with `ignore_missing` flag. 

Contributes to https://github.com/USACE/cwms-data-api/issues/1731