### PR TITLE
fix error key that uses spaces instead of underscores

### DIFF
--- a/schema/src/cwms/cwms_log_ingest_pkg_body.sql
+++ b/schema/src/cwms/cwms_log_ingest_pkg_body.sql
@@ -880,7 +880,7 @@ begin
    exception
       when no_data_found then
          cwms_err.raise(
-            'ITEM DOES NOT EXIST',
+            'ITEM_DOES_NOT_EXIST',
             'Application log file',
             cwms_util.get_db_office_id(p_office_id)
             ||'/'
@@ -1028,7 +1028,7 @@ begin
    exception
       when no_data_found then
          cwms_err.raise(
-            'ITEM DOES NOT EXIST',
+            'ITEM_DOES_NOT_EXIST',
             'Application log file',
             cwms_util.get_db_office_id(p_office_id)
             ||'/'
@@ -1221,7 +1221,7 @@ begin
    exception
       when no_data_found then
          cwms_err.raise(
-            'ITEM DOES NOT EXIST',
+            'ITEM_DOES_NOT_EXIST',
             'Application log file',
             cwms_util.get_db_office_id(p_office_id)
             ||'/'
@@ -1302,7 +1302,7 @@ begin
    exception
       when no_data_found then
          cwms_err.raise(
-            'ITEM DOES NOT EXIST',
+            'ITEM_DOES_NOT_EXIST',
             'Application log file',
             cwms_util.get_db_office_id(p_office_id)
             ||'/'

--- a/schema/src/cwms/cwms_pool_pkg_body.sql
+++ b/schema/src/cwms/cwms_pool_pkg_body.sql
@@ -127,7 +127,7 @@ begin
       and upper(pool_name) = upper(p_old_name);
    exception
       when no_data_found then
-         cwms_err.raise('ITEM DOES NOT EXIST', 'Pool name', l_office_id||'/'||p_old_name);
+         cwms_err.raise('ITEM_DOES_NOT_EXIST', 'Pool name', l_office_id||'/'||p_old_name);
    end;
    if l_rec.office_code != cwms_util.user_office_code and
       cwms_util.user_office_code != cwms_util.db_office_code_all
@@ -189,7 +189,7 @@ begin
       and upper(pool_name) = upper(p_pool_name);
    exception
       when no_data_found then
-         cwms_err.raise('ITEM DOES NOT EXIST', 'Pool name', l_office_id||'/'||p_pool_name);
+         cwms_err.raise('ITEM_DOES_NOT_EXIST', 'Pool name', l_office_id||'/'||p_pool_name);
    end;
    if l_rec.office_code != cwms_util.user_office_code and
       cwms_util.user_office_code != cwms_util.db_office_code_all


### PR DESCRIPTION
"ITEM DOES NOT EXIST" vs "ITEM_DOES_NOT_EXIST"